### PR TITLE
feat: add a task for installing dependencies

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -4,9 +4,10 @@
 
 Some example commands are:
 
-    $ npx projen synth    // synthesise your CDK project
-    $ npx projen --help   // see all available commands (test, lint, etc.)
-    $ npx projen          // update the scaffold itself
+    $ npx projen synth           // synthesise your CDK project
+    $ npx projen dependencies    // install dependencies based on lockfile e.g. during CI
+    $ npx projen --help          // see all available commands (test, lint, etc.)
+    $ npx projen                 // update the scaffold itself
 
 Reminder: this starter-kit uses projen (https://github.com/projen/projen).
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ export class GuCDKTypescriptProject extends TypeScriptAppProject {
     this.removeTask('watch');
 
     // Define our own tasks
+    this.addTask('dependencies', { exec: this.package.installCommand, description: 'Install dependencies based on lockfile' });
     this.addTask('test', { exec: 'jest', description: 'Run tests' });
     this.addTask('lint', { exec: 'eslint --ext .ts --no-error-on-unmatched-pattern lib/**', description: 'Lint sources using eslint' });
     this.lintFix = this.addTask('lint:fix', { exec: 'eslint --ext .ts --no-error-on-unmatched-pattern --fix lib/**', description: 'Lint sources using eslint' });

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ export class GuCDKTypescriptProject extends TypeScriptAppProject {
     this.removeTask('watch');
 
     // Define our own tasks
-    this.addTask('dependencies', { exec: this.package.installCommand, description: 'Install dependencies based on lockfile' });
+    this.addTask('dependencies', { exec: this.package.installCommand, description: 'Install dependencies based on lockfile e.g. during CI' });
     this.addTask('test', { exec: 'jest', description: 'Run tests' });
     this.addTask('lint', { exec: 'eslint --ext .ts --no-error-on-unmatched-pattern lib/**', description: 'Lint sources using eslint' });
     this.lintFix = this.addTask('lint:fix', { exec: 'eslint --ext .ts --no-error-on-unmatched-pattern --fix lib/**', description: 'Lint sources using eslint' });

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -196,7 +196,7 @@ tsconfig.tsbuildinfo
         ],
       },
       "dependencies": Object {
-        "description": "Install dependencies based on lockfile",
+        "description": "Install dependencies based on lockfile e.g. during CI",
         "name": "dependencies",
         "steps": Array [
           Object {
@@ -472,9 +472,10 @@ tsconfig.tsbuildinfo
 
 Some example commands are:
 
-    $ npx projen synth    // synthesise your CDK project
-    $ npx projen --help   // see all available commands (test, lint, etc.)
-    $ npx projen          // update the scaffold itself
+    $ npx projen synth           // synthesise your CDK project
+    $ npx projen dependencies    // install dependencies based on lockfile e.g. during CI
+    $ npx projen --help          // see all available commands (test, lint, etc.)
+    $ npx projen                 // update the scaffold itself
 
 Reminder: this starter-kit uses projen (https://github.com/projen/projen).
 

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -195,6 +195,15 @@ tsconfig.tsbuildinfo
           },
         ],
       },
+      "dependencies": Object {
+        "description": "Install dependencies based on lockfile",
+        "name": "dependencies",
+        "steps": Array [
+          Object {
+            "exec": "yarn install --check-files --frozen-lockfile",
+          },
+        ],
+      },
       "diff": Object {
         "description": "diff CDK stack",
         "name": "diff",
@@ -607,6 +616,7 @@ export class MyStack extends GuStack {
     "prettier": "@guardian/prettier",
     "scripts": Object {
       "default": "npx projen default",
+      "dependencies": "npx projen dependencies",
       "diff": "npx projen diff",
       "eject": "npx projen eject",
       "lint": "npx projen lint",


### PR DESCRIPTION
Related to https://github.com/guardian/cdk-app-ts/pull/4.

When using [external modules](https://github.com/projen/projen#projects-in-external-modules) (like this one) with `projen`, the package itself must be declared as a dependency e.g.:

```typescript
const { VueJsProject } = require('projen-vuejs');

const project = new VueJsProject({
  name: 'my-vuejs-sample',
  description: "my awesome vue project",
  // ...
  devDeps: [
    'projen-vuejs'
  ]
});

project.synth();
```

When a project is created with the `new` command this dependency is installed automatically. However, when checked out on another machine (e.g. during CI), the `npx projen` command (which usually takes care of installing dependencies) will not work. This is because the `@guardian/cdk-app-ts` dependency is not (yet) present in `node_modules`.

Consequently, this PR adds a specific task to install the necessary dependencies. Without this it is necessary to explicitly install dependencies using `yarn`/`npm`, so this task helps to keep projects package-manager agnostic.